### PR TITLE
extend readme and add vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "dev",
+            "problemMatcher": [],
+            "label": "npm: build snark assets",
+            "detail": "node builder.js hash circuits-compiled keys true",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ A basic circom project that verifies that a private preimage hashes to a claimed
 
 ## Building assets
 
-After you edit a circom file like `hash/circuit.circom`, you'll need to rebuild your assets. Use `yarn dev` or `ctrl-shift-b` in vscode to compile circuits, generate zkey (deterministic), generate a proof for the `input.json` input, and verify the proof.
+After you edit a circom file like `hash/circuit.circom`, you'll need to recompile circuits, generate zkey (deterministic), generate a proof for the `input.json` input, and verify the proof.
+
+Theres three ways to build:
+
+- Use `yarn dev`
+- Use vscode npm scripts explorer [run button](https://user-images.githubusercontent.com/38270282/90230165-68adf100-de19-11ea-9ac8-e23173d962a0.gif)
+- `ctrl-shift-b` in vscode
+
+Irrelevant intermediate build files are gitignored and don't need to be checked in.
 
 ### Warning
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # circom-starter
-A basic circom project with jacob rosenthal's scripts. Verifies that a private preimage hashes to a claimed hash.
+
+A basic circom project that verifies that a private preimage hashes to a claimed hash.
+
+## prereqs
 
 `yarn` to install dependencies
 
-`yarn dev` to compile circuit, generate zkey (deterministic), generate a proof for the `input.json` input, and verify the proof.
+## Building assets
+
+After you edit a circom file like `hash/circuit.circom`, you'll need to rebuild your assets. Use `yarn dev` or `ctrl-shift-b` in vscode to compile circuits, generate zkey (deterministic), generate a proof for the `input.json` input, and verify the proof.
+
+### Warning
+
+This method for development only. These assets can't be used for production as they're created with a deterministic secret that we've checked into the directory (the .env file) and thus isn't very secret anymore. However the benefit of this is allowing you to visually audit changes during commit and pull request process.
+
+## extending with more circuits
+
+- Create a new directory for your new circuit, lets say hash2
+- Add hash2 after hash in the package.json dev script as a comma seperated list `hash,hash2`
+- add a hash2_beacon entry the .env file

--- a/package.json
+++ b/package.json
@@ -3,6 +3,19 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "description": "A basic circom project that verifies that a private preimage hashes to a claimed hash.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/briangu33/circom-starter.git"
+  },
+  "bugs": {
+    "url": "https://github.com/briangu33/circom-starter/issues"
+  },
+  "author": "Brian Gu",
+  "contributors": [
+    "Jacob Rosenthal"
+  ],
+  "homepage": "https://github.com/briangu33/circom-starter#readme",
   "dependencies": {},
   "devDependencies": {
     "circom": "^0.5.34",

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,9 +125,9 @@ blake2b-wasm@^1.1.0:
   dependencies:
     nanoassert "^1.0.0"
 
-"blake2b-wasm@git+https://github.com/jbaylina/blake2b-wasm.git":
+"blake2b-wasm@https://github.com/jbaylina/blake2b-wasm.git":
   version "2.1.0"
-  resolved "git+https://github.com/jbaylina/blake2b-wasm.git#0d5f024b212429c7f50a7f533aa3a2406b5b42b3"
+  resolved "https://github.com/jbaylina/blake2b-wasm.git#0d5f024b212429c7f50a7f533aa3a2406b5b42b3"
   dependencies:
     nanoassert "^1.0.0"
 


### PR DESCRIPTION
Explain how to extend with more circuits.
Removed my name from readme as it's got my stink on it all the same.
Add a default vscode task to build with ctrl-shift-b (It doesnt seem like theres a built in way to detect the file name and build on save without an external plugin so this seems like a fine solution for now)
